### PR TITLE
Correct clone link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Note that if you have special characters in your password, the QR code will not 
     `cd ~/MagicMirror/modules`
   
   2. Clone this repository
-  `git clone git@github.com:TeraTech/MMM-WiFiPassword.git`
+  `git clone https://github.com/TeraTech/MMM-WiFiPassword.git`
   
   3. Make changes to your `config.js` file.  
   


### PR DESCRIPTION
Using the git@github.com link resulted in permissions denied error. 