### PR TITLE
fixing issues with some android scanners

### DIFF
--- a/MMM-WiFiPassword.css
+++ b/MMM-WiFiPassword.css
@@ -9,7 +9,7 @@ img {
 }
 
 .qr-image {
-  padding-top:0;
+  padding: 8px;
 }
 
 .text {

--- a/MMM-WiFiPassword.js
+++ b/MMM-WiFiPassword.js
@@ -1,8 +1,8 @@
 Module.register("MMM-WiFiPassword", {  
   defaults: {
 	  qrSize: 125,
-	  colorDark: "#fff",
-	  colorLight: "#000",
+	  colorDark: "#000",
+	  colorLight: "#fff",
 	  authType: "WPA", // WEP, WPA, NONE
 	  network: "REQUIRED", // Your Network ID
 	  password: "REQUIRED", // Your Network Password
@@ -57,7 +57,7 @@ Module.register("MMM-WiFiPassword", {
 	  var qrDiv = document.createElement("div");
 	  qrDiv.id = "qrdiv";
 	  qrDiv.className = "qr-image";
-	  qrDiv.style = "width=" + this.config.qrSize + "px";
+	  qrDiv.style = "width:" + this.config.qrSize + "px; background-color:" + this.config.colorLight;
 	  if (this.config.layoutVertical) {
 		qrDiv.className += " layout-vertical";
 	  } else {


### PR DESCRIPTION
This is regarding issue #5 

We need an actual border around the QR code for this to be compatible with different QR code scanners.
See: [reason nr. 6 on this link](https://www.qrcode-monkey.com/6-reasons-why-your-qr-code-is-not-working)
-> added padding for the qr-image class.

In addition, the colors are inverted in the defaults, which also makes this run into errors on some scanners (see reason nr. 1 on the same link above).

Tested the implementation and it works. Made the background of the qr-image class use the "colorLight" specified color, so that you can still switch back to "full inverted" mode