### PR TITLE
adding support for MMM-Modal module

### DIFF
--- a/MMM-WiFiPassword.js
+++ b/MMM-WiFiPassword.js
@@ -122,8 +122,30 @@ Module.register("MMM-WiFiPassword", {
 		  };
 		  
 		  var qrCode = new QRCode(qrDiv, qrOptions);
-		  
 		  break;
+
+		  case "WIFIPASSWORD_MODAL":
+			var fetchQrCode = document.getElementById("qrdiv").innerHTML;
+			this.sendNotification("OPEN_MODAL", {
+			  template: "WifiPasswordModal.njk",
+			  data: {
+				// Send config as data input to template
+				layoutVertical: this.config.layoutVertical,
+				qrSize: this.config.qrSize,
+				header: this.config.header,
+				colorLight: this.config.colorLight,
+				network: this.config.network,
+				password: this.config.password,
+				authType: this.config.authType,
+				showNetwork: this.config.showNetwork,
+				showPassword: this.config.showPassword,
+				showAuthType: this.config.showAuthType,
+				debug: this.config.debug,
+				// Send actual content
+				content: fetchQrCode,
+			  },
+			});
+			break;
 	  }
   },
   

--- a/README.md
+++ b/README.md
@@ -51,3 +51,15 @@ modules:[
 | `showAuthType`  | Show your authentication type. `true` `false` | true |
 | `debug`  | Displays raw QR text. `true` `false` | false |
 
+## Notifications
+
+You can interact with this module with the following `notifications`:
+
+| Notification | Payload | Description | Requirements |
+| ------------ | ------- | ----------- | ------------ |
+| `WIFIPASSWORD_MODAL`  | - | When receiving this notification, the module will Open a modal popup where it shows the QR code. Useful for integrations with touch screens | [MMM-Modal](https://github.com/fewieden/MMM-Modal) |
+
+
+## Supported modules
+
+This module has support for ["MMM-Modal"](https://github.com/fewieden/MMM-Modal). See [Notifications](#notifications) above.

--- a/WifiPasswordModal.njk
+++ b/WifiPasswordModal.njk
@@ -1,0 +1,11 @@
+<div id="WifiPassword" class="text" {% if not data.layoutVertical %}style="height:{{data.qrSize}}px"{% endif %}>
+  <div id="qrdivModal" class="qr-image {% if data.layoutVertical %}layout-vertical{% else %}layout-horizontal{% endif %}" style="width:{{data.qrSize}}px; background-color:{{data.colorLight}}">
+    {{data.content | safe}}
+  </div>
+  <div id="textDivModal">
+    {% if data.showNetwork %}<p class="text network"><b>Network:</b> {{data.network}}</p>{% endif %}
+    {% if data.showPassword %}<p class="text password"><b>Password:</b> {{data.password}}</p>{% endif %}
+    {% if data.showAuthType %}<p class="text network-type"><b>Authentication Type:</b> {{data.authType}}</p>{% endif %}
+    {% if data.debug %}<p class="text debug"><b>QR String:</b> {{data.qrText}}</p>{% endif %}
+  </div>
+</div>


### PR DESCRIPTION
Adding support for it to work with the [MMM-Modal](https://github.com/fewieden/MMM-Modal) module by @fewieden

When receiving a `WIFIPASSWORD_MODAL` notification, it will create a modal and show your wifi code on screen.

**An example usecase**
1. Using `MMM-Modal` with config
```
    {
      module: 'MMM-Modal',
      position: 'fullscreen_below',
      config: {
        timer: false,
        touch: true,
      }
    },
```
2. Using `MMM-Touch` with touchscreen display with following config:
```
    {
      // Have this at the bottom of your modules, or else it will "push" down other modules comming after it, even tho it is "hidden"
      module: "MMM-Touch",
      position: "top_right",
      config: {
        useDisplay: false,
        defaultMode: "showWifiQr",
        gestureCommands: {
          "showWifiQr": {
            "DOUBLE_TAP_1": (commander, gesture) => {
              // Show Wifi QR code
              commander.sendNotification("WIFIPASSWORD_MODAL")
            },
          }
        }
      }
    },
```
3. And, of course `MMM-WifiPassword` with your specific config
```
    {
      module: "MMM-WiFiPassword",
      position: "bottom_right",
      config: {
        qrSize: 300,
        network: "someNetwork",
        password: "mySuperSecretPassword",
        showNetwork: false,
        showPassword: false,
        showAuthType: false,
      }
    },
```